### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 TabDump For iOS
 ---------------
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=562aa6bb249256010021138a&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/562aa6bb249256010021138a/build/latest)
 
 Read http://tabdump.com by **Stefan Constantinescu** ([@WhatTheBit](https://twitter.com/WhatTheBit)) on your iOS device. Download on [the App Store](https://itunes.apple.com/us/app/tab-dump/id868214144).
 


### PR DESCRIPTION
We've recently launched buddybuild - which is a mobile iteration platform that ties together continuous integration, continuous delivery and an iterative feedback solution into a single, seamless solution.

We really liked Tab Dump on Github and wanted to offer you a free continuous integration system to make sure that your app always works!

This badge will tell you the latest build status of your app.

For more information, please email: team@buddybuild.com